### PR TITLE
Week3/issue#12 모달 컴포넌트 구현

### DIFF
--- a/src/components/common/Modal/AlertModal/index.tsx
+++ b/src/components/common/Modal/AlertModal/index.tsx
@@ -32,12 +32,12 @@ export const AlertModal = ({
       <ModalContent>
         <ModalHeader>
           <Box
-            background="ivory"
+            background="primary_background"
+            color="primary"
             width="fit-content"
             padding="0.5rem"
             rounded="full"
             marginBottom="0.5rem"
-            color="orange"
           >
             {icon}
           </Box>
@@ -49,7 +49,7 @@ export const AlertModal = ({
             fontWeight="medium"
             paddingTop="0.3rem"
             marginLeft="0.5rem"
-            color="gray"
+            color="text_detail"
           >
             {description}
           </Text>
@@ -58,8 +58,7 @@ export const AlertModal = ({
           <Button
             onClick={onClose}
             variant="outline"
-            color="orange"
-            borderColor="orange"
+            colorScheme="primary"
             fontSize="small"
             height="fit-content"
             paddingY="0.5rem"

--- a/src/components/common/Modal/AlertModal/index.tsx
+++ b/src/components/common/Modal/AlertModal/index.tsx
@@ -1,0 +1,74 @@
+import { ReactElement } from 'react'
+
+import {
+  Box,
+  Button,
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from '@chakra-ui/react'
+
+type AlertModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  icon: ReactElement
+  title: string
+  description: string
+}
+
+export const AlertModal = ({
+  isOpen,
+  onClose,
+  icon,
+  title,
+  description,
+}: AlertModalProps) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          <Box
+            background="ivory"
+            width="fit-content"
+            padding="0.5rem"
+            rounded="full"
+            marginBottom="0.5rem"
+            color="orange"
+          >
+            {icon}
+          </Box>
+          <Text fontSize="large" marginLeft="0.5rem">
+            {title}
+          </Text>
+          <Text
+            fontSize="small"
+            fontWeight="medium"
+            paddingTop="0.3rem"
+            marginLeft="0.5rem"
+            color="gray"
+          >
+            {description}
+          </Text>
+        </ModalHeader>
+        <ModalFooter>
+          <Button
+            onClick={onClose}
+            variant="outline"
+            color="orange"
+            borderColor="orange"
+            fontSize="small"
+            height="fit-content"
+            paddingY="0.5rem"
+            paddingX="1.2rem"
+          >
+            닫기
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/components/common/Modal/ConfirmModal/index.tsx
+++ b/src/components/common/Modal/ConfirmModal/index.tsx
@@ -34,12 +34,12 @@ export const ConfirmModal = ({
       <ModalContent>
         <ModalHeader>
           <Box
-            background="ivory"
+            background="primary_background"
+            color="primary"
             width="fit-content"
             padding="0.5rem"
             rounded="full"
             marginBottom="0.5rem"
-            color="orange"
           >
             {icon}
           </Box>
@@ -51,7 +51,7 @@ export const ConfirmModal = ({
             fontWeight="medium"
             paddingTop="0.3rem"
             marginLeft="0.5rem"
-            color="gray"
+            color="text_detail"
           >
             {description}
           </Text>
@@ -60,8 +60,7 @@ export const ConfirmModal = ({
           <Button
             onClick={onClose}
             variant="outline"
-            color="orange"
-            borderColor="orange"
+            colorScheme="primary"
             fontSize="small"
             height="fit-content"
             paddingY="0.5rem"
@@ -85,8 +84,7 @@ export const ConfirmModalButton = ({
 }: ConfirmModalButtonProps) => {
   return (
     <Button
-      backgroundColor="orange"
-      color="white"
+      colorScheme="primary"
       fontSize="small"
       height="fit-content"
       paddingY="0.5rem"

--- a/src/components/common/Modal/ConfirmModal/index.tsx
+++ b/src/components/common/Modal/ConfirmModal/index.tsx
@@ -1,0 +1,99 @@
+import { ButtonHTMLAttributes, ReactElement, ReactNode } from 'react'
+
+import {
+  Box,
+  Button,
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from '@chakra-ui/react'
+
+type ConfirmModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  icon: ReactElement
+  title: string
+  description: string
+  confirmButton: ReactNode
+}
+
+export const ConfirmModal = ({
+  isOpen,
+  onClose,
+  icon,
+  title,
+  description,
+  confirmButton,
+}: ConfirmModalProps) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          <Box
+            background="ivory"
+            width="fit-content"
+            padding="0.5rem"
+            rounded="full"
+            marginBottom="0.5rem"
+            color="orange"
+          >
+            {icon}
+          </Box>
+          <Text fontSize="large" marginLeft="0.5rem">
+            {title}
+          </Text>
+          <Text
+            fontSize="small"
+            fontWeight="medium"
+            paddingTop="0.3rem"
+            marginLeft="0.5rem"
+            color="gray"
+          >
+            {description}
+          </Text>
+        </ModalHeader>
+        <ModalFooter gap="0.5rem">
+          <Button
+            onClick={onClose}
+            variant="outline"
+            color="orange"
+            borderColor="orange"
+            fontSize="small"
+            height="fit-content"
+            paddingY="0.5rem"
+            paddingX="1.2rem"
+          >
+            닫기
+          </Button>
+          {confirmButton}
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+interface ConfirmModalButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const ConfirmModalButton = ({
+  children,
+  onClick,
+}: ConfirmModalButtonProps) => {
+  return (
+    <Button
+      backgroundColor="orange"
+      color="white"
+      fontSize="small"
+      height="fit-content"
+      paddingY="0.5rem"
+      paddingX="1.2rem"
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  )
+}

--- a/src/components/common/Modal/FormModal/index.tsx
+++ b/src/components/common/Modal/FormModal/index.tsx
@@ -37,12 +37,12 @@ export const FormModal = ({
       <ModalContent>
         <ModalHeader>
           <Box
-            background="ivory"
+            background="primary_background"
+            color="primary"
             width="fit-content"
             padding="0.5rem"
             rounded="full"
             marginBottom="0.5rem"
-            color="orange"
           >
             {icon}
           </Box>
@@ -54,7 +54,7 @@ export const FormModal = ({
             fontWeight="medium"
             paddingTop="0.3rem"
             marginLeft="0.5rem"
-            color="gray"
+            color="text_detail"
           >
             {description}
           </Text>
@@ -64,8 +64,7 @@ export const FormModal = ({
           <Button
             onClick={onClose}
             variant="outline"
-            color="orange"
-            borderColor="orange"
+            colorScheme="primary"
             fontSize="small"
             height="fit-content"
             paddingY="0.6rem"
@@ -89,8 +88,7 @@ export const FormConfirmModalButton = ({
 }: FormConfirmModalButtonProps) => {
   return (
     <Button
-      backgroundColor="orange"
-      color="white"
+      colorScheme="primary"
       fontSize="small"
       height="fit-content"
       paddingY="0.6rem"

--- a/src/components/common/Modal/FormModal/index.tsx
+++ b/src/components/common/Modal/FormModal/index.tsx
@@ -1,0 +1,103 @@
+import { ButtonHTMLAttributes, ReactElement, ReactNode } from 'react'
+
+import {
+  Box,
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from '@chakra-ui/react'
+
+type FormModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  icon: ReactElement
+  title: string
+  description: string
+  children: ReactNode
+  confirmButton: ReactNode
+}
+
+export const FormModal = ({
+  isOpen,
+  onClose,
+  icon,
+  title,
+  description,
+  children,
+  confirmButton,
+}: FormModalProps) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          <Box
+            background="ivory"
+            width="fit-content"
+            padding="0.5rem"
+            rounded="full"
+            marginBottom="0.5rem"
+            color="orange"
+          >
+            {icon}
+          </Box>
+          <Text fontSize="large" marginLeft="0.5rem">
+            {title}
+          </Text>
+          <Text
+            fontSize="small"
+            fontWeight="medium"
+            paddingTop="0.3rem"
+            marginLeft="0.5rem"
+            color="gray"
+          >
+            {description}
+          </Text>
+        </ModalHeader>
+        <ModalBody>{children}</ModalBody>
+        <ModalFooter gap="0.5rem">
+          <Button
+            onClick={onClose}
+            variant="outline"
+            color="orange"
+            borderColor="orange"
+            fontSize="small"
+            height="fit-content"
+            paddingY="0.6rem"
+            width="full"
+          >
+            취소하기
+          </Button>
+          {confirmButton}
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+interface FormConfirmModalButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const FormConfirmModalButton = ({
+  children,
+  onClick,
+}: FormConfirmModalButtonProps) => {
+  return (
+    <Button
+      backgroundColor="orange"
+      color="white"
+      fontSize="small"
+      height="fit-content"
+      paddingY="0.6rem"
+      width="full"
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  )
+}

--- a/src/components/common/Modal/TestModal/index.tsx
+++ b/src/components/common/Modal/TestModal/index.tsx
@@ -1,13 +1,26 @@
+import { useRef } from 'react'
 import { BiCheckCircle } from 'react-icons/bi'
 
-import { Button, Flex, useDisclosure } from '@chakra-ui/react'
+import {
+  Button,
+  Flex,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Input,
+  useDisclosure,
+} from '@chakra-ui/react'
 
 import { AlertModal } from '../AlertModal'
 import { ConfirmModal, ConfirmModalButton } from '../ConfirmModal'
+import { FormConfirmModalButton, FormModal } from '../FormModal'
 
 export const TestModal = () => {
   const alertDisclosure = useDisclosure()
   const confirmDisclosure = useDisclosure()
+  const formDisclosure = useDisclosure()
+
+  const initialRef = useRef(null)
 
   return (
     <Flex
@@ -48,6 +61,39 @@ export const TestModal = () => {
             </ConfirmModalButton>
           }
         />
+      </div>
+      <div>
+        <Button onClick={formDisclosure.onOpen}>Form Modal 사용 방법</Button>
+        <FormModal
+          isOpen={formDisclosure.isOpen}
+          onClose={formDisclosure.onClose}
+          icon={<BiCheckCircle />}
+          title="제목입니다"
+          description="대충 설명적으면 됩니다."
+          confirmButton={
+            <FormConfirmModalButton
+              onClick={() => {
+                console.log('여기에 액션 추가하기')
+                formDisclosure.onClose()
+              }}
+            >
+              제출하기
+            </FormConfirmModalButton>
+          }
+        >
+          <FormControl>
+            <FormLabel fontSize="small">입력 받기</FormLabel>
+            <Input
+              ref={initialRef}
+              placeholder="안녕하세요~"
+              size="sm"
+              borderRadius="6"
+            />
+            <FormHelperText textAlign="center" fontSize="small">
+              입력 설명 여기에 넣으면 됩니다.
+            </FormHelperText>
+          </FormControl>
+        </FormModal>
       </div>
     </Flex>
   )

--- a/src/components/common/Modal/TestModal/index.tsx
+++ b/src/components/common/Modal/TestModal/index.tsx
@@ -1,22 +1,54 @@
 import { BiCheckCircle } from 'react-icons/bi'
 
-import { Button, useDisclosure } from '@chakra-ui/react'
+import { Button, Flex, useDisclosure } from '@chakra-ui/react'
 
 import { AlertModal } from '../AlertModal'
+import { ConfirmModal, ConfirmModalButton } from '../ConfirmModal'
 
 export const TestModal = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure()
+  const alertDisclosure = useDisclosure()
+  const confirmDisclosure = useDisclosure()
 
   return (
-    <div>
-      <Button onClick={onOpen}>Alert Modal 사용 방법</Button>
-      <AlertModal
-        isOpen={isOpen}
-        onClose={onClose}
-        icon={<BiCheckCircle />}
-        title="제목입니다"
-        description="대충 설명적으면 됩니다."
-      />
-    </div>
+    <Flex
+      flexDirection="column"
+      gap="2rem"
+      alignItems="center"
+      justifyContent="center"
+      height="100vh"
+    >
+      <div>
+        <Button onClick={alertDisclosure.onOpen}>Alert Modal 사용 방법</Button>
+        <AlertModal
+          isOpen={alertDisclosure.isOpen}
+          onClose={alertDisclosure.onClose}
+          icon={<BiCheckCircle />}
+          title="제목입니다"
+          description="대충 설명적으면 됩니다."
+        />
+      </div>
+      <div>
+        <Button onClick={confirmDisclosure.onOpen}>
+          Confirm Modal 사용 방법
+        </Button>
+        <ConfirmModal
+          isOpen={confirmDisclosure.isOpen}
+          onClose={confirmDisclosure.onClose}
+          icon={<BiCheckCircle />}
+          title="제목입니다"
+          description="대충 설명적으면 됩니다."
+          confirmButton={
+            <ConfirmModalButton
+              onClick={() => {
+                console.log('여기에 액션 추가하기')
+                confirmDisclosure.onClose()
+              }}
+            >
+              확인
+            </ConfirmModalButton>
+          }
+        />
+      </div>
+    </Flex>
   )
 }

--- a/src/components/common/Modal/TestModal/index.tsx
+++ b/src/components/common/Modal/TestModal/index.tsx
@@ -1,0 +1,22 @@
+import { BiCheckCircle } from 'react-icons/bi'
+
+import { Button, useDisclosure } from '@chakra-ui/react'
+
+import { AlertModal } from '../AlertModal'
+
+export const TestModal = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
+  return (
+    <div>
+      <Button onClick={onOpen}>Alert Modal 사용 방법</Button>
+      <AlertModal
+        isOpen={isOpen}
+        onClose={onClose}
+        icon={<BiCheckCircle />}
+        title="제목입니다"
+        description="대충 설명적으면 됩니다."
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
### PR Type

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약

트리거 발생 시 보여지는 작은 화면의 UI

### 상세 내용

- 해당 컴포넌트는 [Chakra UI의 Modal 컴포넌트](https://v2.chakra-ui.com/docs/components/modal/usage)의 UI와 hook을 사용했습니다.
- Alert/Confirm/Form Modal 총 3가지의 UI를 구현했습니다.
  - Alert Modal: 아이콘, 제목, 설명을 props로 받아 생성, 사용자의 입력은 창 닫기만 가능
  - Confirm Modal: Alert Modal에서 확장, 사용자가 confirm 버튼을 클릭 시 특정 action 수행
  - Form Modal: Confirm Modal에서 확장, 사용자의 입력을 받을 수 있고, confirm 버튼 클릭 시 특정 action 수행
- 각 Modal의 사용 방법은 TestModal 컴포넌트에서 확인할 수 있습니다.

### 이슈 번호

- closed #12 

### 스크린샷(선택)

#### Alert Modal
<img width="551" alt="image" src="https://github.com/user-attachments/assets/18f5f858-3837-4b96-a00b-c1a72496d96d">

#### Confirm Modal
<img width="546" alt="image" src="https://github.com/user-attachments/assets/328de21f-01d6-4edb-b8eb-4dd2e0761cee">

#### Form Modal
<img width="533" alt="image" src="https://github.com/user-attachments/assets/8b6005ad-c3f7-40b5-9697-9853c68bc9eb">

### 기타
