### PR TITLE
Week3/issue#11 Chakra color theme 추가

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,5 +32,6 @@ module.exports = {
   plugins: ['react', '@typescript-eslint', 'prettier'],
   rules: {
     'react/react-in-jsx-scope': 'off',
+    'import/prefer-default-export': 'off',
   },
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,10 +5,11 @@ import { ChakraProvider } from '@chakra-ui/react'
 
 import App from './App'
 import './index.css'
+import theme from './styles/theme'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ChakraProvider>
+    <ChakraProvider theme={theme}>
       <App />
     </ChakraProvider>
   </StrictMode>

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,63 @@
+import { extendTheme } from '@chakra-ui/react'
+
+const theme = extendTheme({
+  colors: {
+    orange: {
+      50: '#FFF7ED',
+      300: '#FFE7CC',
+      400: '#FECC88',
+      500: '#FFBB55',
+      600: '#FFAA21',
+    },
+    brown: {
+      50: '#FBF8F5',
+      300: '#EDE5DA',
+      400: '#DCC7AC',
+      500: '#B2967E',
+      600: '#917A68',
+    },
+    black: {
+      50: '#FAFAFA',
+      100: '#F5F5F5',
+      200: '#EFEFEF',
+      300: '#E2E2E2',
+      400: '#BFBFBF',
+      500: '#A0A0A0',
+      600: '#777777',
+      700: '#636363',
+      800: '#444444',
+      900: '#232527',
+    },
+
+    // 컴포넌트 colorScheme 설정용
+    primary: {
+      50: '#FFF7ED',
+      100: '#FFE7CC',
+      500: '#FFAA21',
+      600: '#F29D13',
+      700: '#CF8200',
+    },
+    secondary: {
+      50: '#FBF8F5',
+      100: '#EDE5DA',
+      500: '#DCC7AC',
+      600: '#B2967E',
+      700: '#917A68',
+    },
+  },
+  semanticTokens: {
+    colors: {
+      primary: 'orange.600',
+      primary_background: 'orange.50',
+      secondary: 'brown.400',
+      secondary_background: 'brown.50',
+      destructive: '#FC2724',
+      kakao: '#FEE500',
+      text: 'black.900',
+      text_secondary: 'black.800',
+      text_detail: 'black.600',
+    },
+  },
+})
+
+export default theme


### PR DESCRIPTION
### PR Type

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [x] Other: 디자인 세팅

### 요약

프로젝트에서 사용하는 공통 색상을 변수로 설정하기

### 상세 내용

- 기본 컬러, 시멘틱 컬러, colorScheme을 추가했습니다.
- 기본 컬러는 Chakra 컴포넌트에서 색상으로 사용가능한 모든 속성에 `색상.숫자`로 접근 가능합니다.
  - ex) `<Text color={brown.400}>test</Text>`
  - 추가된 색상 목록은 아래의 이미지를 참고해주세요
- 시멘틱 컬러는 primary, secondary, destructive, kakao, text, primary_background... 로 접근 가능합니다.
  - ex) `<Text color={primary}>test</Text>`
- colorSheme은 Chakra 컴포넌트에서 colorSheme 속성에 `primary`, `seconary`로 접근 가능합니다.
    - ex) `<Button colorSheme={primary}>test</Button>`
    - 버튼 이외에도 colorSheme을 속성으로 갖는 모든 컴포넌트에서 사용가능합니다.

### 이슈 번호

- close: #11 

### 스크린샷(선택)

#### 기본 커스텀 컬러
<img width="557" alt="image" src="https://github.com/user-attachments/assets/553480db-f1e7-4937-adbb-33fcc8b300da">

#### 시멘틱 컬러
<img width="451" alt="image" src="https://github.com/user-attachments/assets/62b4af82-2c20-4532-9dcd-42e19a8f1500">

#### colorSheme
<img width="502" alt="image" src="https://github.com/user-attachments/assets/7ccb2506-1f65-4728-afeb-a5e75540be74">