### PR TITLE
Week5/issue#40 그룹 섹션 UI 구현

### DIFF
--- a/src/components/features/Layout/GroupSection/GroupHeader/index.tsx
+++ b/src/components/features/Layout/GroupSection/GroupHeader/index.tsx
@@ -1,0 +1,14 @@
+import { BiDonateHeart } from 'react-icons/bi'
+
+import { Flex, HStack, Text } from '@chakra-ui/react'
+
+export const GroupHeader = () => {
+  return (
+    <Flex alignItems="center" justifyContent="space-between" paddingRight={3}>
+      <HStack padding={2} paddingY={1}>
+        <BiDonateHeart size={20} />
+        <Text fontWeight="bold">쿠키 주기</Text>
+      </HStack>
+    </Flex>
+  )
+}

--- a/src/components/features/Layout/GroupSection/GroupList/GroupListItem/index.tsx
+++ b/src/components/features/Layout/GroupSection/GroupList/GroupListItem/index.tsx
@@ -1,18 +1,27 @@
 import { Avatar, HStack, Text, Tooltip } from '@chakra-ui/react'
 
+import { useSeletedGroupStore } from '@/stores/selected-group'
 import { Group } from '@/types'
 
 interface GroupListItemProps {
   group: Group
+  selectedGroup: number | 'ALL'
 }
 
-export const GroupListItem = ({ group }: GroupListItemProps) => {
+export const GroupListItem = ({ group, selectedGroup }: GroupListItemProps) => {
+  const setSeletedGroupId = useSeletedGroupStore((state) => state.setGroupId)
+
   return (
     <HStack
       paddingY={1.5}
       paddingX={2}
       width="full"
       _hover={{ background: 'brown.50', cursor: 'pointer' }}
+      borderRight={selectedGroup === group.groupdId ? 3 : 0}
+      background={selectedGroup === group.groupdId ? 'brown.50' : ''}
+      borderRightColor="brown.400"
+      borderRightStyle="solid"
+      onClick={() => setSeletedGroupId(group.groupdId)}
     >
       <Tooltip
         label={`${group.groupName} 페이지`}

--- a/src/components/features/Layout/GroupSection/GroupList/GroupListItem/index.tsx
+++ b/src/components/features/Layout/GroupSection/GroupList/GroupListItem/index.tsx
@@ -1,0 +1,27 @@
+import { Avatar, HStack, Text, Tooltip } from '@chakra-ui/react'
+
+import { Group } from '@/types'
+
+interface GroupListItemProps {
+  group: Group
+}
+
+export const GroupListItem = ({ group }: GroupListItemProps) => {
+  return (
+    <HStack
+      paddingY={1.5}
+      paddingX={2}
+      width="full"
+      _hover={{ background: 'brown.50', cursor: 'pointer' }}
+    >
+      <Tooltip
+        label={`${group.groupName} 페이지`}
+        aria-label="그룹 페이지로 이동하기"
+        placement="top"
+      >
+        <Avatar width={7} height={7} src={group.groupdImageUrl} />
+      </Tooltip>
+      <Text>{group.groupName}</Text>
+    </HStack>
+  )
+}

--- a/src/components/features/Layout/GroupSection/GroupList/index.tsx
+++ b/src/components/features/Layout/GroupSection/GroupList/index.tsx
@@ -1,0 +1,41 @@
+import { Avatar, Flex, HStack, Text } from '@chakra-ui/react'
+
+import { Group } from '@/types'
+
+interface GroupListProps {
+  groups: Group[]
+}
+
+export const GroupList = ({ groups }: GroupListProps) => {
+  return (
+    <Flex
+      flexDirection="column"
+      alignItems="start"
+      paddingX={2}
+      overflowY="scroll"
+      maxHeight="32rem"
+      gap={2}
+    >
+      <Flex flexDirection="column">
+        <Text fontSize="small" color="text_detail" paddingY={1}>
+          모든 친구에게
+        </Text>
+        <HStack paddingY={1.5}>
+          <Avatar width={7} height={7} />
+          <Text>ALL</Text>
+        </HStack>
+      </Flex>
+      <Flex flexDirection="column">
+        <Text fontSize="small" color="text_detail" paddingY={1}>
+          그룹 친구에게 - {groups.length}
+        </Text>
+        {groups.map((group) => (
+          <HStack key={group.groupdId} paddingY={1.5}>
+            <Avatar width={7} height={7} src={group.groupdImageUrl} />
+            <Text>{group.groupName}</Text>
+          </HStack>
+        ))}
+      </Flex>
+    </Flex>
+  )
+}

--- a/src/components/features/Layout/GroupSection/GroupList/index.tsx
+++ b/src/components/features/Layout/GroupSection/GroupList/index.tsx
@@ -1,6 +1,10 @@
-import { Avatar, Flex, HStack, Text } from '@chakra-ui/react'
+import { BiQuestionMark } from 'react-icons/bi'
+
+import { Center, Flex, HStack, Text } from '@chakra-ui/react'
 
 import { Group } from '@/types'
+
+import { GroupListItem } from './GroupListItem'
 
 interface GroupListProps {
   groups: Group[]
@@ -11,29 +15,32 @@ export const GroupList = ({ groups }: GroupListProps) => {
     <Flex
       flexDirection="column"
       alignItems="start"
-      paddingX={2}
       overflowY="scroll"
       maxHeight="32rem"
       gap={2}
     >
-      <Flex flexDirection="column">
-        <Text fontSize="small" color="text_detail" paddingY={1}>
+      <Flex flexDirection="column" width="full">
+        <Text fontSize="small" color="text_detail" paddingY={1} paddingX={2}>
           모든 친구에게
         </Text>
-        <HStack paddingY={1.5}>
-          <Avatar width={7} height={7} />
+        <HStack
+          paddingY={1.5}
+          paddingX={2}
+          width="full"
+          _hover={{ background: 'brown.50', cursor: 'pointer' }}
+        >
+          <Center background="primary" width={7} height={7} rounded="full">
+            <BiQuestionMark size={20} color="white" />
+          </Center>
           <Text>ALL</Text>
         </HStack>
       </Flex>
-      <Flex flexDirection="column">
-        <Text fontSize="small" color="text_detail" paddingY={1}>
-          그룹 친구에게 - {groups.length}
+      <Flex flexDirection="column" width="full">
+        <Text fontSize="small" color="text_detail" paddingY={1} paddingX={2}>
+          그룹 친구에게
         </Text>
         {groups.map((group) => (
-          <HStack key={group.groupdId} paddingY={1.5}>
-            <Avatar width={7} height={7} src={group.groupdImageUrl} />
-            <Text>{group.groupName}</Text>
-          </HStack>
+          <GroupListItem key={group.groupdId} group={group} />
         ))}
       </Flex>
     </Flex>

--- a/src/components/features/Layout/GroupSection/GroupList/index.tsx
+++ b/src/components/features/Layout/GroupSection/GroupList/index.tsx
@@ -2,6 +2,7 @@ import { BiQuestionMark } from 'react-icons/bi'
 
 import { Center, Flex, HStack, Text } from '@chakra-ui/react'
 
+import { useSeletedGroupStore } from '@/stores/selected-group'
 import { Group } from '@/types'
 
 import { GroupListItem } from './GroupListItem'
@@ -11,6 +12,9 @@ interface GroupListProps {
 }
 
 export const GroupList = ({ groups }: GroupListProps) => {
+  const groupId = useSeletedGroupStore((state) => state.groupId)
+  const setSeletedGroup = useSeletedGroupStore((state) => state.setGroupId)
+
   return (
     <Flex
       flexDirection="column"
@@ -28,6 +32,11 @@ export const GroupList = ({ groups }: GroupListProps) => {
           paddingX={2}
           width="full"
           _hover={{ background: 'brown.50', cursor: 'pointer' }}
+          borderRight={groupId === 'ALL' ? 3 : 0}
+          borderRightColor="brown.400"
+          borderRightStyle="solid"
+          background={groupId === 'ALL' ? 'brown.50' : ''}
+          onClick={() => setSeletedGroup('ALL')}
         >
           <Center background="primary" width={7} height={7} rounded="full">
             <BiQuestionMark size={20} color="white" />
@@ -40,7 +49,11 @@ export const GroupList = ({ groups }: GroupListProps) => {
           그룹 친구에게
         </Text>
         {groups.map((group) => (
-          <GroupListItem key={group.groupdId} group={group} />
+          <GroupListItem
+            key={group.groupdId}
+            group={group}
+            selectedGroup={groupId}
+          />
         ))}
       </Flex>
     </Flex>

--- a/src/components/features/Layout/GroupSection/index.tsx
+++ b/src/components/features/Layout/GroupSection/index.tsx
@@ -1,5 +1,44 @@
-import { Box } from '@chakra-ui/react'
+import { Divider, Flex } from '@chakra-ui/react'
+
+import { GroupHeader } from './GroupHeader'
+import { GroupList } from './GroupList'
 
 export const GroupSection = () => {
-  return <Box background="white" width="200px" height="full" />
+  return (
+    <Flex
+      flexDirection="column"
+      background="white"
+      width="200px"
+      height="full"
+      gap={1}
+    >
+      <GroupHeader />
+      <Divider />
+      <GroupList groups={mockGroupList} />
+    </Flex>
+  )
 }
+
+const mockGroupList = [
+  {
+    groupdId: 1,
+    groupName: '최우수수수퍼노바',
+    groupdImageUrl: '',
+    groupDescription: '안녕하세요',
+    groupMemberCount: 10,
+  },
+  {
+    groupdId: 2,
+    groupName: '일이삼사오육칠팔구십',
+    groupdImageUrl: '',
+    groupDescription: '안녕하세요',
+    groupMemberCount: 10,
+  },
+  {
+    groupdId: 3,
+    groupName: '카테캠 2기',
+    groupdImageUrl: '',
+    groupDescription: '안녕하세요',
+    groupMemberCount: 10,
+  },
+]

--- a/src/stores/selected-group.ts
+++ b/src/stores/selected-group.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+interface SelectedGroupProps {
+  groupId: number | 'ALL'
+  setGroupId: (groupId: number | 'ALL') => void
+}
+
+export const useSeletedGroupStore = create<SelectedGroupProps>((set) => ({
+  groupId: 'ALL',
+  setGroupId: (groupId) => {
+    set({ groupId })
+  },
+}))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,11 @@ export type Friend = {
   imageUrl: string
   isFriend: boolean
 }
+
+export type Group = {
+  groupdId: number
+  groupName: string
+  groupdImageUrl: string
+  groupDescription: string
+  groupMemberCount: number
+}


### PR DESCRIPTION
### PR Type

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약

- 메인 레이아웃 좌측의 그룹 섹션 UI

### 상세 내용

- 그룹 아이템을 클릭하면 전역 store에 그룹 id를 저장합니다
  - 그룹 id의 타입은 'ALL' 또는 number입니다
- 그룹 프로필을 클릭할 때 그룹 페이지로 이동하게 디자인을 수정했습니다
  - 그룹 프로필을 hover하면 페이지로 이동하라는 tooltip ui가 보이게했습니다

_현재 컴포넌트 설계가 최적화되지 않은 상태입니다. 이후에 `레이아웃 수정` 이슈를 만들고 리팩토링 진행할 예정입니다._

### 이슈 번호

close #40 

### 스크린샷(선택)
#### store에 저장된 그룹id가 ALL일 때
<img width="1155" alt="image" src="https://github.com/user-attachments/assets/a7e1a5da-4be1-449b-acae-b451d3ece8c4">

#### 그룹 프로필을 hover 했을 때
<img width="1182" alt="image" src="https://github.com/user-attachments/assets/4bfada31-cad0-4b8e-81e5-37feab604257">
