### PR TITLE
Week7/issue#76 authorization instance 에러 해결

### DIFF
--- a/src/api/instance/index.ts
+++ b/src/api/instance/index.ts
@@ -28,7 +28,7 @@ export const authorizationInstance = initInstance({
 
 authorizationInstance.interceptors.request.use(
   (request) => {
-    const authToken = useAuthTokenStore((state) => state.authToken)
+    const { authToken } = useAuthTokenStore.getState()
 
     if (authToken) {
       request.headers.Authorization = `Bearer ${authToken}`


### PR DESCRIPTION
- getState() 메서드로 상태를 직접 가져옴

### PR Type

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약

- authorization instance에서 auth token을 직접 가져오도록 수정

### 상세 내용
- 자세한 버그 상황은 이슈를 확인해주세요

### 이슈 번호

close #76 

### 스크린샷(선택)
